### PR TITLE
Add support for vector inputs

### DIFF
--- a/R/to_number.R
+++ b/R/to_number.R
@@ -11,7 +11,7 @@
 #' @importFrom magrittr %>%
 #' @examples
 #' to_number("one thousand and seventy two")
-#'
+#' to_number(c("thirty seven", "forty two"))
 #'
 
 to_number <- function(x) {
@@ -20,7 +20,7 @@ to_number <- function(x) {
     stop("magrittr is needed for this function to work. Please install it.",
          call. = FALSE)
   }
-    x <- 
+    expr <- 
     gsub("-", " ", x) %>% 
       gsub("eleventh", "+11", . , ignore.case = T) %>%
       gsub("twelfth", "+12", . , ignore.case = T ) %>%
@@ -112,5 +112,6 @@ to_number <- function(x) {
     gsub("\\+\\+", "\\+\\(", . , ignore.case = T ) %>%
     gsub("\\)\\+\\)", "\\)", . , ignore.case = T )
 
-  return(as.integer(eval(parse(text = x))))
+  result <- sapply(expr, function(y) eval(parse(text = y)), USE.NAMES = FALSE)
+  setNames(result, x)
 }

--- a/R/to_number.R
+++ b/R/to_number.R
@@ -112,7 +112,7 @@ to_number <- function(x) {
     gsub("\\+\\+", "\\+\\(", . , ignore.case = T ) %>%
     gsub("\\)\\+\\)", "\\)", . , ignore.case = T )
   
-  if (grepl('[[:alpha:]]', expr))
+  if (any(grepl('[[:alpha:]]', expr)))
     stop("expression ", expr, " cannot be evaluated")
 
   result <- sapply(expr, function(y) eval(parse(text = y)), USE.NAMES = FALSE)

--- a/R/to_number.R
+++ b/R/to_number.R
@@ -83,7 +83,7 @@ to_number <- function(x) {
       gsub("sixth", "+6", . , ignore.case = T) %>%
       gsub("seventh", "+7", . , ignore.case = T) %>%
       gsub("eighth", "+8", . , ignore.case = T) %>%
-      gsub("nineth", "+9", . , ignore.case = T) %>%
+      gsub("ninth", "+9", . , ignore.case = T) %>%
     gsub("one", "+1", . , ignore.case = T) %>%
     gsub("two", "+2", . , ignore.case = T) %>%
     gsub("three", "+3", . , ignore.case = T) %>%
@@ -95,7 +95,7 @@ to_number <- function(x) {
     gsub("nine", "+9", . , ignore.case = T) %>%
     
     gsub("millions", ")*(1000000)+(0", . , ignore.case = T) %>%
-    gsub("millon", ")*(1000000)+(0", . , ignore.case = T) %>%
+    gsub("million", ")*(1000000)+(0", . , ignore.case = T) %>%
     gsub("thousandth", ")*(1000)+(0", . , ignore.case = T) %>%
     gsub("thousand", ")*(1000)+(0", . , ignore.case = T) %>%
     gsub("hundredth", "+100", . , ignore.case = T) %>%

--- a/R/to_number.R
+++ b/R/to_number.R
@@ -20,25 +20,25 @@ to_number <- function(x) {
     stop("magrittr is needed for this function to work. Please install it.",
          call. = FALSE)
   }
-    expr <- 
+  expr <- 
     gsub("-", " ", x) %>% 
-      gsub("eleventh", "+11", . , ignore.case = T) %>%
-      gsub("twelfth", "+12", . , ignore.case = T ) %>%
-      gsub("thirteenth", "+13", . , ignore.case = T) %>%
-      gsub("fourteenth", "+14", . , ignore.case = T) %>%
-      gsub("fifteenth", "+15", . , ignore.case = T) %>%
-      gsub("sixteenth", "+16", . , ignore.case = T) %>%
-      gsub("seventeenth", "+17", . , ignore.case = T) %>%
-      gsub("eighteenth", "+18", . , ignore.case = T) %>%
-      gsub("nineteenth", "+19", . , ignore.case = T) %>%
-      gsub("twentieth", "+20", . , ignore.case = T) %>%
-      gsub("thirtieth", "+30", . , ignore.case = T) %>%
-      gsub("fortieth", "+40", . , ignore.case = T) %>%
-      gsub("fiftieth", "+50", . , ignore.case = T) %>%
-      gsub("sixtieth", "+60", . , ignore.case = T) %>%
-      gsub("seventieth", "+70", . , ignore.case = T) %>%
-      gsub("eightieth", "+80", . , ignore.case = T) %>%
-      gsub("ninetieth", "+90", . , ignore.case = T) %>%
+    gsub("eleventh", "+11", . , ignore.case = T) %>%
+    gsub("twelfth", "+12", . , ignore.case = T ) %>%
+    gsub("thirteenth", "+13", . , ignore.case = T) %>%
+    gsub("fourteenth", "+14", . , ignore.case = T) %>%
+    gsub("fifteenth", "+15", . , ignore.case = T) %>%
+    gsub("sixteenth", "+16", . , ignore.case = T) %>%
+    gsub("seventeenth", "+17", . , ignore.case = T) %>%
+    gsub("eighteenth", "+18", . , ignore.case = T) %>%
+    gsub("nineteenth", "+19", . , ignore.case = T) %>%
+    gsub("twentieth", "+20", . , ignore.case = T) %>%
+    gsub("thirtieth", "+30", . , ignore.case = T) %>%
+    gsub("fortieth", "+40", . , ignore.case = T) %>%
+    gsub("fiftieth", "+50", . , ignore.case = T) %>%
+    gsub("sixtieth", "+60", . , ignore.case = T) %>%
+    gsub("seventieth", "+70", . , ignore.case = T) %>%
+    gsub("eightieth", "+80", . , ignore.case = T) %>%
+    gsub("ninetieth", "+90", . , ignore.case = T) %>%
     gsub("eleven", "+11", . , ignore.case = T) %>%
     gsub("twelve", "+12", . , ignore.case = T ) %>%
     gsub("thirteen", "+13", . , ignore.case = T) %>%
@@ -57,33 +57,33 @@ to_number <- function(x) {
     gsub("eighty", "+80", . , ignore.case = T) %>%
     gsub("ninety", "+90", . , ignore.case = T) %>%
     
-      gsub("one hundredth", "+100", . , ignore.case = T) %>%
-      gsub("two hundredth", "+200", . , ignore.case = T) %>%
-      gsub("three hundredth", "+300", . , ignore.case = T) %>%
-      gsub("four hundredth", "+400", . , ignore.case = T) %>%
-      gsub("five hundredth", "+500", . , ignore.case = T) %>%
-      gsub("six hundredth", "+600", . , ignore.case = T) %>%
-      gsub("seven hundredth", "+700", . , ignore.case = T) %>%
-      gsub("eight hundredth", "+800", . , ignore.case = T) %>%
-      gsub("nine hundredth", "+900", . , ignore.case = T) %>%
-      gsub("one hundred", "+100", . , ignore.case = T) %>%
-      gsub("two hundred", "+200", . , ignore.case = T) %>%
-      gsub("three hundred", "+300", . , ignore.case = T) %>%
-      gsub("four hundred", "+400", . , ignore.case = T) %>%
-      gsub("five hundred", "+500", . , ignore.case = T) %>%
-      gsub("six hundred", "+600", . , ignore.case = T) %>%
-      gsub("seven hundred", "+700", . , ignore.case = T) %>%
-      gsub("eight hundred", "+800", . , ignore.case = T) %>%
-      gsub("nine hundred", "+900", . , ignore.case = T) %>%
-      gsub("first", "+1", . , ignore.case = T) %>%
-      gsub("second", "+2", . , ignore.case = T) %>%
-      gsub("third", "+3", . , ignore.case = T) %>%
-      gsub("fourth", "+4", . , ignore.case = T) %>%
-      gsub("fifth", "+5", . , ignore.case = T) %>%
-      gsub("sixth", "+6", . , ignore.case = T) %>%
-      gsub("seventh", "+7", . , ignore.case = T) %>%
-      gsub("eighth", "+8", . , ignore.case = T) %>%
-      gsub("ninth", "+9", . , ignore.case = T) %>%
+    gsub("one hundredth", "+100", . , ignore.case = T) %>%
+    gsub("two hundredth", "+200", . , ignore.case = T) %>%
+    gsub("three hundredth", "+300", . , ignore.case = T) %>%
+    gsub("four hundredth", "+400", . , ignore.case = T) %>%
+    gsub("five hundredth", "+500", . , ignore.case = T) %>%
+    gsub("six hundredth", "+600", . , ignore.case = T) %>%
+    gsub("seven hundredth", "+700", . , ignore.case = T) %>%
+    gsub("eight hundredth", "+800", . , ignore.case = T) %>%
+    gsub("nine hundredth", "+900", . , ignore.case = T) %>%
+    gsub("one hundred", "+100", . , ignore.case = T) %>%
+    gsub("two hundred", "+200", . , ignore.case = T) %>%
+    gsub("three hundred", "+300", . , ignore.case = T) %>%
+    gsub("four hundred", "+400", . , ignore.case = T) %>%
+    gsub("five hundred", "+500", . , ignore.case = T) %>%
+    gsub("six hundred", "+600", . , ignore.case = T) %>%
+    gsub("seven hundred", "+700", . , ignore.case = T) %>%
+    gsub("eight hundred", "+800", . , ignore.case = T) %>%
+    gsub("nine hundred", "+900", . , ignore.case = T) %>%
+    gsub("first", "+1", . , ignore.case = T) %>%
+    gsub("second", "+2", . , ignore.case = T) %>%
+    gsub("third", "+3", . , ignore.case = T) %>%
+    gsub("fourth", "+4", . , ignore.case = T) %>%
+    gsub("fifth", "+5", . , ignore.case = T) %>%
+    gsub("sixth", "+6", . , ignore.case = T) %>%
+    gsub("seventh", "+7", . , ignore.case = T) %>%
+    gsub("eighth", "+8", . , ignore.case = T) %>%
+    gsub("ninth", "+9", . , ignore.case = T) %>%
     gsub("one", "+1", . , ignore.case = T) %>%
     gsub("two", "+2", . , ignore.case = T) %>%
     gsub("three", "+3", . , ignore.case = T) %>%
@@ -111,7 +111,10 @@ to_number <- function(x) {
     gsub("\\(0\\(", "", . , ignore.case = T ) %>%
     gsub("\\+\\+", "\\+\\(", . , ignore.case = T ) %>%
     gsub("\\)\\+\\)", "\\)", . , ignore.case = T )
+  
+  if (grepl('[[:alpha:]]', expr))
+    stop("expression ", expr, " cannot be evaluated")
 
   result <- sapply(expr, function(y) eval(parse(text = y)), USE.NAMES = FALSE)
-  setNames(result, x)
+  setNames(as.integer(result), x)
 }

--- a/tests/testthat/tests.R
+++ b/tests/testthat/tests.R
@@ -95,7 +95,7 @@ test_that("to_number returns a correct translation from string.", {
 })
 
 test_that("to_number returns a correct translation from string.", {
-  result <- to_number("ninety nineth")
+  result <- to_number("ninety ninth")
   target <- 99
   expect_equivalent(result, target)
 })
@@ -153,11 +153,11 @@ test_that("to_number returns a correct translation from string.", {
 
 
 
-# test_that("to_number works ok with millions from string.", {
-#   result <- to_number("two million four hundred and eighty two thousand one hundred and three")
-#   target <- 2482103
-#   expect_equivalent(result, target)
-# })
+test_that("to_number works ok with millions from string.", {
+  result <- to_number("two million four hundred and eighty two thousand one hundred and three")
+  target <- 2482103
+  expect_equivalent(result, target)
+})
 
 
 test_that("to_number error message when unexpected string.", {

--- a/tests/testthat/tests.R
+++ b/tests/testthat/tests.R
@@ -150,8 +150,11 @@ test_that("to_number returns a correct translation from string.", {
   expect_equivalent(result, target)
 })
 
-
-
+test_that("to number works with vector inputs.", {
+  result <- to_number(c("one", "two", "forty-two"))
+  target <- c(1, 2, 42)
+  expect_equivalent(result, target)
+})
 
 test_that("to_number works ok with millions from string.", {
   result <- to_number("two million four hundred and eighty two thousand one hundred and three")


### PR DESCRIPTION
Previous implementation, if passed a vector of length > 1, would give unexpected results. Now it returns a named vector.

You should now be able to perform actions like

```r
to_number(c('one hundred', 'fifty'))
```

and it will return

```
one hundred       fifty 
        100          50 
```